### PR TITLE
deploy / README.md: rimuoviamo '_' tra i caratteri ammessi per heroku

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -102,7 +102,7 @@ Creating app... done, ⬢ <nome-del-blog>
 
 > **Note** Sostituisci a <nome-del-blog> (**comprese le parentesi <>**) un nome per il tuo blog considerando che sarà quello che apparirà nella url come ad esempio `https://<nome-del-blog>.herokuapp.com`.
 
-> **Warning** Ricordati che il nome deve essere composto solo di caratteri minuscoli, numeri, caratteri `-` e `_`. Non sono ammessi altri caratteri, e in particolare non sono ammessi spazi nel nome.
+> **Warning** Ricordati che il nome deve essere composto solo di caratteri minuscoli, numeri e `-`. Non sono ammessi altri caratteri, e in particolare non sono ammessi spazi nel nome.
 
 L'ultima cosa che ci rimane da fare è caricare il nostro codice su Heroku e per farlo utilizzeremo `git`. Il prossimo comando che digiterai oltre a caricare il nostro codice sulla nostra app installerà Python, installerà per noi le dipendenze, raccoglierà i file statici e avvierà la nostra applicazione.
 


### PR DESCRIPTION
### Perchè?

Se proviamo a lanciare il comando da CLI heroku create NOME_APPLICAZIONE che contiene un underscore nel nome, ricevo questo errore:

```
Name must start with a letter, end with a letter or digit and can only contain lowercase letters, digits, and dashes.

```

### Descrizione

rimuovo dal tutorial la menzione degli underscore come carattere ammesso nel nome progetto heroku