### PR TITLE
Usiamo https nei link

### DIFF
--- a/how_the_internet_works/README.md
+++ b/how_the_internet_works/README.md
@@ -1,6 +1,6 @@
 # Come funziona Internet
 
-> Questo capitolo è ispirato ad un discorso di Jessica McKellar "How the Internet Works" ([http://web.mit.edu/jesstess/www/](http://web.mit.edu/jesstess/www/)).
+> Questo capitolo è ispirato ad un discorso di Jessica McKellar "How the Internet Works" ([https://web.mit.edu/jesstess/www/](https://web.mit.edu/jesstess/www/)).
 
 Scommettiamo che usi Internet tutti i giorni. Ma sai davvero che cosa succede quando digiti un indirizzo come [https://djangogirls.org](https://djangogirls.org) nel tuo browser e premi `invio`?
 
@@ -16,7 +16,7 @@ Abbiamo creato un'immagine! Ecco com'è:
 
 ![Internet](images/internet_1.png)
 
-Sembra caotico, vero? Infatti è una rete di macchine collegate (i _server_ che abbiamo menzionato prima). Centinaia di migliaia di macchine! Molti, molti chilometri di cavi in tutto il mondo! Puoi visitare un sito di Submarine Cable Map ([http://submarinecablemap.com](http://submarinecablemap.com)) per vedere quanto è complicata la rete. Ecco uno screenshot dal sito web:
+Sembra caotico, vero? Infatti è una rete di macchine collegate (i _server_ che abbiamo menzionato prima). Centinaia di migliaia di macchine! Molti, molti chilometri di cavi in tutto il mondo! Puoi visitare un sito di Submarine Cable Map ([https://submarinecablemap.com](https://submarinecablemap.com)) per vedere quanto è complicata la rete. Ecco uno screenshot dal sito web:
 
 ![Submarine](/how_the_internet_works/images/internet_2.png)
 

--- a/intro_to_command_line/README.md
+++ b/intro_to_command_line/README.md
@@ -422,7 +422,7 @@ Questi sono solo alcuni dei comandi che puoi eseguire sulla tua command line, ma
 
 Se sei curioso/a, [ss64.com][1] contiene una guida completa ai comandi per tutti i sistemi operativi.
 
- [1]: http://ss64.com
+ [1]: https://ss64.com
 
 ## Fatto?
 

--- a/whats_next/README.md
+++ b/whats_next/README.md
@@ -23,6 +23,6 @@ Più avanti potrai provare le risorse elencate qui sotto. Sono tutte molto consi
 * [Corso Code Academy Python](https://www.codecademy.com/en/tracks/python)
 * [Corso Code Academy HTML & CSS](https://www.codecademy.com/tracks/web)
 * [Tutorial Django Carrots](https://github.com/ggcarrots/django-carrots)
-* [Il libro "Learn Python The Hard Way"](http://learnpythonthehardway.org/book/)
+* [Il libro "Learn Python The Hard Way"](https://learnpythonthehardway.org/python3/)
 * [Lezioni video "Inizia con Django"](http://www.gettingstartedwithdjango.com/)
 * [Il libro "Two Scoops of Django: Best Practices for Django 1.11 book"](https://www.twoscoopspress.com/collections/frontpage/products/two-scoops-of-django-1-11)

--- a/whats_next/README.md
+++ b/whats_next/README.md
@@ -8,13 +8,13 @@ Prenditi una pausa e rilassati. Hai veramente fatto un passo da gigante!
 
 Dopo di che, assicurati di:
 
-* Seguire Django Girls su [Facebook](http://facebook.com/djangogirls) o [Twitter](https://twitter.com/djangogirls)
+* Seguire Django Girls su [Facebook](https://facebook.com/djangogirls) o [Twitter](https://twitter.com/djangogirls)
 * Seguire Django Girls Italia su [Facebook](https://www.facebook.com/djangogirlsIT/) o [Twitter](https://twitter.com/djangogirlsIT) per rimanere aggiornata
 * Aggiungerti al gruppo Telegram [![DjangoGirls It](https://img.shields.io/badge/telegram-%40djangogirls__it-blue.svg)](https://t.me/djangogirls_ita) per rimanere in contatto con i Coach: è il posto giusto se hai dubbi o se vuoi continuare questo percorso.
 
 ### Mi puoi consigliare ulteriori risorse?
 
-Si! Vai avanti e prova il nostro libro dal titolo [Django Girls Tutorial: estensioni](http://djangogirls.gitbooks.io/django-girls-tutorial-extensions/).
+Si! Vai avanti e prova il nostro libro dal titolo [Django Girls Tutorial: estensioni](https://djangogirls.gitbooks.io/django-girls-tutorial-extensions/).
 
 Più avanti potrai provare le risorse elencate qui sotto. Sono tutte molto consigliate!
 


### PR DESCRIPTION
### Descrizione

Preferiamo https nei link dove funziona. Visto che ci siamo aggiorniamo il link a learn python the hard way alla versione per python3.

### Perchè?

Perchè siamo nel 2019 :)